### PR TITLE
Tidy up clean targets, add -j auto Sphinx option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,7 +73,7 @@ instance/
 .scrapy
 
 # Sphinx documentation
-docs/_build/
+doc/_build/
 
 # PyBuilder
 .pybuilder/

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -5,7 +5,7 @@
 SPHINXOPTS    = -j auto
 SPHINXBUILD   = sphinx-build
 SOURCEDIR     = source
-BUILDDIR      = build
+BUILDDIR      = _build
 
 # Put it first so that "make" without argument is like "make help".
 help:

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    =
+SPHINXOPTS    = -j auto
 SPHINXBUILD   = sphinx-build
 SOURCEDIR     = source
 BUILDDIR      = build
@@ -21,4 +21,6 @@ help:
 
 # Customized clean due to examples gallery
 clean:
-	rm -rf build
+	rm -rf $(BUILDDIR)/*
+	rm -rf $(SOURCEDIR)/examples
+	find . -type d -name "_autosummary" -exec rm -rf {} +

--- a/doc/make.bat
+++ b/doc/make.bat
@@ -8,7 +8,7 @@ if "%SPHINXBUILD%" == "" (
 	set SPHINXBUILD=sphinx-build
 )
 set SOURCEDIR=source
-set BUILDDIR=build
+set BUILDDIR=_build
 
 if "%1" == "" goto help
 if "%1" == "clean" goto clean

--- a/doc/make.bat
+++ b/doc/make.bat
@@ -11,6 +11,7 @@ set SOURCEDIR=source
 set BUILDDIR=build
 
 if "%1" == "" goto help
+if "%1" == "clean" goto clean
 
 %SPHINXBUILD% >NUL 2>NUL
 if errorlevel 9009 (
@@ -26,6 +27,11 @@ if errorlevel 9009 (
 )
 
 %SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:clean
+rmdir /s /q %BUILDDIR% > /NUL 2>&1 
+for /d /r %SOURCEDIR% %%d in (_autosummary) do @if exist "%%d" rmdir /s /q "%%d"
 goto end
 
 :help

--- a/src/ansys/templates/python/common/{{cookiecutter.__project_name_slug}}/.gitignore
+++ b/src/ansys/templates/python/common/{{cookiecutter.__project_name_slug}}/.gitignore
@@ -73,7 +73,7 @@ instance/
 .scrapy
 
 # Sphinx documentation
-docs/_build/
+doc/_build/
 
 # PyBuilder
 .pybuilder/

--- a/src/ansys/templates/python/common/{{cookiecutter.__project_name_slug}}/doc/Makefile
+++ b/src/ansys/templates/python/common/{{cookiecutter.__project_name_slug}}/doc/Makefile
@@ -2,10 +2,10 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    =
+SPHINXOPTS    = -j auto
 SPHINXBUILD   = sphinx-build
 SOURCEDIR     = source
-BUILDDIR      = build
+BUILDDIR      = _build
 
 # Put it first so that "make" without argument is like "make help".
 help:
@@ -21,4 +21,6 @@ help:
 
 # Customized clean due to examples gallery
 clean:
-	rm -rf build
+	rm -rf $(BUILDDIR)/*
+	rm -rf $(SOURCEDIR)/examples
+	find . -type d -name "_autosummary" -exec rm -rf {} +

--- a/src/ansys/templates/python/common/{{cookiecutter.__project_name_slug}}/doc/make.bat
+++ b/src/ansys/templates/python/common/{{cookiecutter.__project_name_slug}}/doc/make.bat
@@ -8,9 +8,10 @@ if "%SPHINXBUILD%" == "" (
 	set SPHINXBUILD=sphinx-build
 )
 set SOURCEDIR=source
-set BUILDDIR=build
+set BUILDDIR=_build
 
 if "%1" == "" goto help
+if "%1" == "clean" goto clean
 
 %SPHINXBUILD% >NUL 2>NUL
 if errorlevel 9009 (
@@ -26,6 +27,11 @@ if errorlevel 9009 (
 )
 
 %SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:clean
+rmdir /s /q %BUILDDIR% > /NUL 2>&1 
+for /d /r %SOURCEDIR% %%d in (_autosummary) do @if exist "%%d" rmdir /s /q "%%d"
 goto end
 
 :help


### PR DESCRIPTION
- Clean target consistency for bat and Makefile, remove _autosummary areas.
- Added `-j auto` used by pymapdl and pyfluent
- Changed the recommended build directory name from `build` to `_build` so it's consistent with .gitignore