### PR TITLE
Run pipx ensurepath through "python -m"

### DIFF
--- a/doc/source/getting_started/index.rst
+++ b/doc/source/getting_started/index.rst
@@ -40,7 +40,7 @@ Ensure that `pipx`_ is in your ``PATH`` by running:
 
 .. code:: bash
 
-   pipx ensurepath
+   python -m pipx ensurepath
 
 If you encounter any issues when installing `pip`_, refer to `pipx installation
 guidelines`_.


### PR DESCRIPTION
If pipx is not in the PATH then the command `pipx ensurepath` will not work, but `python -m pipx ensurepath` will