### PR TITLE
Use artifacts in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,12 @@ jobs:
       - name: Build wheel and sdist
         run: |
           python -m build && python -m twine check dist/*
+      - name: Upload wheel and sdist to artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: pyasys-templates-packages
+          path: dist/
+          retention-days: 7
 
   release:
     name: Release
@@ -110,11 +116,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v2
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
           python-version: 3.9
+      - name: Display structure of downloaded files
+        run: ls -R
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
Allows the release job to get access to the distribution files.