### PR TITLE
Update pyproject.toml to use ansys-cookiecutter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 dependencies = [
     "importlib-metadata >=4.0",
     "click>=7.0,<8.0.0",
-    "cookiecutter @ git+https://www.github.com/cookiecutter/cookiecutter.git@2.0.2",
+    "ansys-cookiecutter",
     "isort>=5.10.1",
 ]
 


### PR DESCRIPTION
Given the [issue within cookiecutter's release](https://github.com/cookiecutter/cookiecutter/issues/1636), I've gone ahead and released a renamed, but otherwise identical, `ansys-cookiecutter` package at https://pypi.org/project/ansys-cookiecutter/.

This is by no means a permanent solution, and since the github repo has 16.5k stars, I'm sure that someone will come up with a workaround, fork, or will just post the package. For now, we're using this to get the job done and will take it down once 2.X is released.

Installation of this package is:
```
pip install ansys-cookiecutter
```
and it will show up from `pip list` as `ansys-cookiecutter`, but otherwise it's identical to the actual package. For example both:
```
python -m cookiecutter
```
```
python -c "import cookiecutter"
```
work flawlessly, and otherwise our implementation requires no changes.